### PR TITLE
Implement filtered queries in get requests

### DIFF
--- a/src/main/java/com/google/sps/servlets/ChatroomServlet.java
+++ b/src/main/java/com/google/sps/servlets/ChatroomServlet.java
@@ -15,6 +15,11 @@
 package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
+import java.util.Arrays;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.CompositeFilter;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
@@ -50,21 +55,16 @@ public class ChatroomServlet extends HttpServlet {
         String chatroomID = "null";
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
         Query chatroomQuery = new Query("chatroom");
-        PreparedQuery chatrooms = datastore.prepare(chatroomQuery);
+        chatroomQuery.setFilter(new CompositeFilter(CompositeFilterOperator.AND, Arrays.asList(
+                new FilterPredicate("user1", FilterOperator.EQUAL, userID),
+                new FilterPredicate("user2", FilterOperator.EQUAL, recipientID))));
 
-        for (Entity chatroom : chatrooms.asIterable()) {
-            String chatroomId = (String) chatroom.getProperty("chatroomId");
-            String user1 = (String) chatroom.getProperty("user1");
-            String user2 = (String) chatroom.getProperty("user2");
+        Entity chatroom = datastore.prepare(chatroomQuery).asSingleEntity();
 
-            Chatroom currChatRoom = new Chatroom(chatroomId, user1, user2);
-            List<String> usersList = currChatRoom.getUsers();
-
-            if ((usersList.contains(userID)) && (usersList.contains(recipientID))) {
-                    chatroomID = currChatRoom.getId();
-                    break;
-            }
+        if (chatroom != null) {
+            chatroomID = (String) chatroom.getProperty("chatroomId");
         }
 
         // Check to see if chatroom is empty and make new chatroom
@@ -79,11 +79,13 @@ public class ChatroomServlet extends HttpServlet {
 
         // go through messages and grabs the messages with chatroomID = to the chatroomID passed in
         // then sorts them by timestamp
-        Query messageQuery = new Query("message").addSort("timestamp", SortDirection.ASCENDING);
+        Query messageQuery = new Query("message");
+        messageQuery.setFilter(new FilterPredicate("chatroomId", FilterOperator.EQUAL, chatroomID));
+        messageQuery.addSort("timestamp", SortDirection.ASCENDING);
+
         PreparedQuery results = datastore.prepare(messageQuery);
 
         ArrayList<Message> messagesInChatroom = new ArrayList<Message>();
-
         for (Entity message : results.asIterable()) {
             String messageId = (String) message.getProperty("messageId");
             String chatroomId = (String) message.getProperty("chatroomId");
@@ -94,13 +96,9 @@ public class ChatroomServlet extends HttpServlet {
             Long timestamp = (Long) message.getProperty("timestamp");
 
             Message messageInstance = new Message(messageId, chatroomId, text, translatedText, senderId, recipientId, timestamp);
-          
-            if (chatroomId.equals(chatroomID)){
-                messagesInChatroom.add(messageInstance);
-                System.out.println(messagesInChatroom);
-            }
+            messagesInChatroom.add(messageInstance);
         }
-
+        
         Gson gson = new Gson();
     
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -15,10 +15,45 @@
 package com.google.sps.servlets;
 
 import javax.servlet.ServletInputStream;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.datastore.v1.TransactionOptions;
+import com.google.datastore.v1.TransactionOptions.ReadOnly;
+import com.google.cloud.datastore.Cursor;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
+//import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.EntityQuery;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.ListValue;
+import com.google.cloud.datastore.PathElement;
+import com.google.cloud.datastore.ProjectionEntity;
+//import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.ReadOption;
+import com.google.cloud.datastore.StringValue;
+import com.google.cloud.datastore.StructuredQuery;
+import com.google.cloud.datastore.StructuredQuery.CompositeFilter;
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
+import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
+import com.google.cloud.datastore.Transaction;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.cloud.datastore.StructuredQuery;
+import com.google.cloud.datastore.StructuredQuery.CompositeFilter;
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
+import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
+//import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query;
 import com.google.gson.Gson;
 import java.io.IOException;
@@ -29,6 +64,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
+//import com.google.datastore.v1.PropertyFilter;
+import com.google.datastore.v1.Query.Builder;
 import com.google.sps.servlets.User;
 
 /** Servlet that holds the users on this WebApp */
@@ -41,11 +78,13 @@ public class UserServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String userID = request.getParameter("userId");
+
         Query query = new Query("user");
+        query.setFilter(new Query.FilterPredicate("userId", Query.FilterOperator.EQUAL, userID));
+
         PreparedQuery results = DatastoreServiceFactory.getDatastoreService().prepare(query);
 
         ArrayList<User> users = new ArrayList<User>();
-
         for (Entity user : results.asIterable()) {
             String currUserId = (String) user.getProperty("userId");
             if (currUserId.equals(userID)){


### PR DESCRIPTION
Changed the get requests for /chatroom, /user to query more efficiently

- Functionality/behavior is exactly the same
- Instead of querying all messages then searching for the correct chatroomIDs/userIDs in a for loop, the servlets now use Predicate and Composite Filters to simply query the correct entities
- ChatroomServlet.java line 64: .asSingleEntity() turns single item queries into just a single entity. It returns null if the query is empty (so that's context for the if statement on line 66)